### PR TITLE
Smart4life

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ It shall NOT be edited by hand.
 # HumHub for YunoHost
 
 [![Integration level](https://dash.yunohost.org/integration/humhub.svg)](https://dash.yunohost.org/appci/app/humhub) ![Working status](https://ci-apps.yunohost.org/ci/badges/humhub.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/humhub.maintain.svg)
+
 [![Install HumHub with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=humhub)
 
 *[Lire ce readme en français.](./README_fr.md)*
@@ -18,7 +19,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 HumHub is an open source social network platform with a wide variety of use cases as social intranet, community or collaboration platform. HumHub consists of a core application, which can be extended through additional modules and adjusted to your needs by many configuration options. 
 
 
-**Shipped version:** 1.13.1~ynh1
+**Shipped version:** 1.14.0~ynh1
 
 **Demo:** https://www.humhub.com/en
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -6,6 +6,7 @@ It shall NOT be edited by hand.
 # HumHub pour YunoHost
 
 [![Niveau d’intégration](https://dash.yunohost.org/integration/humhub.svg)](https://dash.yunohost.org/appci/app/humhub) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/humhub.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/humhub.maintain.svg)
+
 [![Installer HumHub avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=humhub)
 
 *[Read this readme in english.](./README.md)*
@@ -18,7 +19,7 @@ Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) po
 HumHub est une plate-forme de réseau social open source avec une grande variété de cas d'utilisation en tant qu'intranet social, plate-forme de communauté ou de collaboration. HumHub se compose d'une application principale, qui peut être étendue grâce à des modules supplémentaires et ajustée à vos besoins par de nombreuses options de configuration.
 
 
-**Version incluse :** 1.13.1~ynh1
+**Version incluse :** 1.14.0~ynh1
 
 **Démo :** https://www.humhub.com/en
 

--- a/check_process
+++ b/check_process
@@ -16,7 +16,7 @@
 		backup_restore=1
 		multi_instance=1
 		port_already_use=0
-		change_url=0
+		change_url=1
 ;;; Options
 Email=
 Notification=none

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://download.humhub.com/downloads/install/humhub-1.13.1.tar.gz
-SOURCE_SUM=ad618f284e131e600024816a42c66a95f84fcc192cd5e2f82d2465cf0c3ed882
+SOURCE_URL=https://www.humhub.com/download/package/humhub-1.14.0.tar.gz
+SOURCE_SUM=87d4496c1ad9d06bf3c8a53e7b20263192d17c52553acf32f017c3feaa6e27d1
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -2,14 +2,15 @@
 location __PATH__/ {
 
   # Path to source
-  alias __FINALPATH__/;
+#sub_path_only  alias __FINALPATH__/;
+#root_path_only  root __FINALPATH__/;
 
   index index.php;
 
   # Common parameter to increase upload size limit in conjunction with dedicated php-fpm file
   #client_max_body_size 50M;
 
-  try_files $uri $uri/ index.php?$args;
+  try_files $uri $uri/ /index.php?$args;
   location ~ [^/]\.php(/|$) {
     fastcgi_split_path_info ^(.+?\.php)(/.*)$;
 

--- a/doc/DISCLAIMER.md
+++ b/doc/DISCLAIMER.md
@@ -1,0 +1,1 @@
+* **Humhub** requires a dedicated **root domain** (e.g. `humhub.domain.tld`) to enable [Pretty URLs](https://docs.humhub.org/docs/admin/installation/#pretty-urls)

--- a/doc/DISCLAIMER_fr.md
+++ b/doc/DISCLAIMER_fr.md
@@ -1,0 +1,1 @@
+* **Humhub** nécessite un **domaine racine** (par ex. `humhub.domain.tld`) pour activer les [Pretty URLs](https://docs.humhub.org/docs/admin/installation/#pretty-urls)

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Enterprise Social Network",
         "fr": "Réseau Social d'Entreprise"
     },
-    "version": "1.13.1~ynh1",
+    "version": "1.14.0~ynh1",
     "url": "https://www.humhub.org",
     "upstream": {
         "license": "AGPL-3.0-only",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -11,7 +11,7 @@ php_dependencies="php${YNH_PHP_VERSION}-imagick php${YNH_PHP_VERSION}-curl php${
 # dependencies used by the app (must be on a single line)
 pkg_dependencies="$php_dependencies"
 
-HUMHUB_AUTH_BASIC_VERSION=0.1.0
+HUMHUB_AUTH_BASIC_VERSION=0.1.2
 HUMHUB_AUTH_BASIC_PATH="/protected/modules/auth-basic"
 
 #=================================================

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+#=================================================
+# GENERIC STARTING
+#=================================================
+# IMPORT GENERIC HELPERS
+#=================================================
+
+source _common.sh
+source /usr/share/yunohost/helpers
+
+#=================================================
+# RETRIEVE ARGUMENTS
+#=================================================
+
+old_domain=$YNH_APP_OLD_DOMAIN
+old_path=$YNH_APP_OLD_PATH
+
+new_domain=$YNH_APP_NEW_DOMAIN
+new_path=$YNH_APP_NEW_PATH
+
+app=$YNH_APP_INSTANCE_NAME
+
+#=================================================
+# LOAD SETTINGS
+#=================================================
+ynh_script_progression --message="Loading installation settings..." --time --weight=1
+
+# Needed for helper "ynh_add_nginx_config"
+final_path=$(ynh_app_setting_get --app=$app --key=final_path)
+
+#=================================================
+# BACKUP BEFORE CHANGE URL THEN ACTIVE TRAP
+#=================================================
+ynh_script_progression --message="Backing up the app before changing its URL (may take a while)..." --time --weight=1
+
+# Backup the current version of the app
+ynh_backup_before_upgrade
+ynh_clean_setup () {
+	# Remove the new domain config file, the remove script won't do it as it doesn't know yet its location.
+	ynh_secure_remove --file="/etc/nginx/conf.d/$new_domain.d/$app.conf"
+
+	# Restore it if the upgrade fails
+	ynh_restore_upgradebackup
+}
+# Exit if an error occurs during the execution of the script
+ynh_abort_if_errors
+
+#=================================================
+# CHECK WHICH PARTS SHOULD BE CHANGED
+#=================================================
+
+change_domain=0
+if [ "$old_domain" != "$new_domain" ]
+then
+	change_domain=1
+fi
+
+change_path=0
+if [ "$old_path" != "$new_path" ]
+then
+	change_path=1
+fi
+
+#=================================================
+# MODIFY URL IN NGINX CONF
+#=================================================
+ynh_script_progression --message="Updating NGINX web server configuration..." --time --weight=1
+
+nginx_conf_path=/etc/nginx/conf.d/$old_domain.d/$app.conf
+
+# Change the path in the NGINX config file
+if [ $change_path -eq 1 ]
+then
+	# Make a backup of the original NGINX config file if modified
+	ynh_backup_if_checksum_is_different --file="$nginx_conf_path"
+	# Set global variables for NGINX helper
+	domain="$old_domain"
+	path_url="$new_path"
+	# Create a dedicated NGINX config
+	ynh_add_nginx_config
+fi
+
+# Change the domain for NGINX
+if [ $change_domain -eq 1 ]
+then
+	# Delete file checksum for the old conf file location
+	ynh_delete_file_checksum --file="$nginx_conf_path"
+	mv $nginx_conf_path /etc/nginx/conf.d/$new_domain.d/$app.conf
+	# Store file checksum for the new config file location
+	ynh_store_file_checksum --file="/etc/nginx/conf.d/$new_domain.d/$app.conf"
+fi
+
+#=================================================
+# RELOAD NGINX
+#=================================================
+ynh_script_progression --message="Reloading NGINX web server..." --time --weight=1
+
+ynh_systemd_action --service_name=nginx --action=reload
+
+#=================================================
+# END OF SCRIPT
+#=================================================
+
+ynh_script_progression --message="Change of URL completed for $app" --time --last

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -28,6 +28,7 @@ ynh_script_progression --message="Loading installation settings..." --time --wei
 
 # Needed for helper "ynh_add_nginx_config"
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
+phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
 
 #=================================================
 # BACKUP BEFORE CHANGE URL THEN ACTIVE TRAP
@@ -90,6 +91,15 @@ then
 	# Store file checksum for the new config file location
 	ynh_store_file_checksum --file="/etc/nginx/conf.d/$new_domain.d/$app.conf"
 fi
+
+#=================================================
+# UPDATE HUMHUB CONFIGURATION
+#=================================================
+ynh_script_progression --message="Updating HUMHUB configuration..." --time --weight=1
+
+pushd $final_path/protected
+	php$phpversion yii settings/set base baseUrl http://$new_domain$new_path
+popd
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -130,8 +130,8 @@ ynh_install_app_dependencies $pkg_dependencies
 ynh_script_progression --message="Upgrading PHP-FPM configuration..." --weight=1
 
 # Create a dedicated PHP-FPM config
-ynh_add_fpm_config --phpversion=$phpversion --usage=$fpm_usage --footprint=$fpm_footprint
 phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
+ynh_add_fpm_config --phpversion=$phpversion --usage=$fpm_usage --footprint=$fpm_footprint
 
 #=================================================
 # NGINX CONFIGURATION


### PR DESCRIPTION
## Problem

- Version 0.1.x of auth basic module doesn't work with humhub 1.14.x

## Solution

- Use version 0.2.0 of auth basic module

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
